### PR TITLE
Remove references to README.nuget.md

### DIFF
--- a/Src/PIXBacen/PIXBacen.csproj
+++ b/Src/PIXBacen/PIXBacen.csproj
@@ -15,7 +15,7 @@
     <RepositoryType>GIT</RepositoryType>
     <PackageTags>pix bacen </PackageTags>
     <PackageIcon>packageLogo.png</PackageIcon>
-    <PackageReadmeFile>README.nuget.md</PackageReadmeFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Version>1.0.0</Version>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>    
   </PropertyGroup>
@@ -35,7 +35,7 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-    <None Include="..\..\README.nuget.md">
+    <None Include="..\..\README.md">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>


### PR DESCRIPTION
NuGet gallery now shows the WakaTime badge (It was added to trusted domains list). No need of specific readme file for it