### PR TITLE
Remove codeclimate steps

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,6 @@ configuration: Release
 environment:
   CODACY_PROJECT_TOKEN:
     secure: bqp3Vwf5Ft5sm/p8WP1AwuSu8msKg1sRYqH28kx2mK39mEN9L15BWl2wKHAUlNKd
-  CODECLIMATE_TOKEN:
-    secure: w2RdqAp3D471W/s2qVXBww3qWIBrzVQPgAaWJHqrnE4FtRB5GGPLGhzr+Pxb3UHIjZnIIndbSZwOTKJQJe8FVVcfrYfLW7HErhqwvZW+Wcg=
 
 dotnet_csproj:
   patch: true
@@ -30,7 +28,6 @@ before_build:
 - cmd: choco install opencover.portable
 - cmd: choco install codecov
 - cmd: curl -L https://github.com/codacy/codacy-coverage-reporter/releases/latest/download/codacy-coverage-reporter-assembly.jar > ./codacy-test-reporter.jar
-- cmd: curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-windows-amd64 > codeclimate-test-reporter.exe
 - cmd: dotnet tool install --global dotnet-sonarscanner
 
 build:
@@ -47,7 +44,6 @@ build_script:
 - ps: if(-Not $env:APPVEYOR_PULL_REQUEST_NUMBER) { $Params += "/d:sonar.branch.name=`"$env:APPVEYOR_REPO_BRANCH`"" }
 - ps: if($env:APPVEYOR_PULL_REQUEST_NUMBER) { $Params += "/d:sonar.pullrequest.key=$env:APPVEYOR_PULL_REQUEST_NUMBER", "/d:sonar.pullrequest.branch=`"$env:APPVEYOR_REPO_BRANCH`"" }
 - ps: Start-process "dotnet" "sonarscanner begin $($Params -join ' ')"
-- codeclimate-test-reporter before-build
 - dotnet build %SOLUTION_NAME%.sln
 - ps: $testProjects = (Get-ChildItem -Path .\Tests\**\ -Recurse -Include *.csproj).Fullname
 - ps: $coverletFormats = @('cobertura', 'lcov', 'opencover')
@@ -59,8 +55,6 @@ build_script:
            dotnet test $testProject /p:CollectCoverage=true /p:CoverletOutputFormat="$coverletFormat"
         }
     }
-- codeclimate-test-reporter format-coverage -t lcov -o "%CD%\Tests\%SOLUTION_NAME%.Tests\code-climate.json" "%CD%\Tests\%SOLUTION_NAME%.Tests\coverage.info"
-- codeclimate-test-reporter upload-coverage -i "%CD%\Tests\%SOLUTION_NAME%.Tests\code-climate.json" -r %CODECLIMATE_TOKEN%
 - codecov -f "%CD%\Tests\%SOLUTION_NAME%.Tests\coverage.opencover.xml"
 - java -jar ./codacy-test-reporter.jar report -l CSharp -t %CODACY_PROJECT_TOKEN% -r "%CD%\Tests\%SOLUTION_NAME%.Tests\coverage.opencover.xml"
 - dotnet sonarscanner end /d:sonar.token="%SONAR_TOKEN%"


### PR DESCRIPTION
### **User description**
## 📑 Description
Remove codeclimate steps

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---





___

### **Description**
- This PR enhances the build configuration by removing CodeClimate integration.
- It cleans up the `appveyor.yml` file by eliminating unnecessary environment variables and commands.
- The changes streamline the build process and focus on other coverage tools.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>appveyor.yml</strong><dd><code>Remove CodeClimate Integration from AppVeyor Configuration</code></dd></summary>
<hr>

appveyor.yml
<li>Removed <code>CODECLIMATE_TOKEN</code> environment variable.<br> <li> Deleted commands related to <code>codeclimate-test-reporter</code>.<br> <li> Cleaned up build script by removing references to CodeClimate.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/PIX-BACEN-SDK-dotnet/pull/204/files#diff-92ab9a36df5d8e9f7076f2fdec59492d1ac2d9cf27ea046767a7fc4d542ef3dc">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove steps related to CodeClimate in the `appveyor.yml` file including the token and commands for downloading, running, and uploading coverage data with CodeClimate.

### Why are these changes being made?

CodeClimate integration is no longer necessary either due to a change in platforms used for code quality, or consolidated coverage reporting to a different tool such as Codacy or SonarQube, as indicated by the presence of existing integrations. Cleaning up unused tools reduces maintenance overhead and potential for misconfigurations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->